### PR TITLE
win32 build

### DIFF
--- a/LICENSE-BINARY
+++ b/LICENSE-BINARY
@@ -1,0 +1,12 @@
+BRDF Explorer
+Copyright Disney Enterprises, Inc. All rights reserved.
+
+See LICENSE for the specific application components license.
+Source code is available at http://disneyanimation.com/
+http://www.disneyanimation.com/technology/brdf.html
+
+Developed with Nokia Qt4.  Qt4 libraries are unmodified and
+dynamically linked LGPL versions. Binaries and source are available at
+http://qt.nokia.com/products.
+
+Windows binary is cross compiled using ming32.

--- a/main.pro
+++ b/main.pro
@@ -1,3 +1,5 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 SUBDIRS += src/brdf
+INCLUDEPATH += ../windows-build/glew-1.9.0/include/
+INCLUDEPATH += ../windows-build/glut-3.7.6-bin/

--- a/make_win32_dist.sh
+++ b/make_win32_dist.sh
@@ -1,0 +1,13 @@
+make clean
+qmake-qt4 -spec linux-mingw32-custom
+make -j 8
+
+rm -rf brdf-win32
+mkdir brdf-win32
+pushd brdf-win32
+cp -a ../src/{data,probes,images,brdfs,shaderTemplates} ./
+cp /jobs2/soft/users/aselle/windows-build/QtSDK/Desktop/Qt/4.6.4/bin/{QtGui4.dll,QtCore4.dll,QtOpenGL4.dll,libgcc_s_dw2-1.dll,mingwm10.dll} ./
+cp ../src/brdf/release/brdf.exe ./
+cp ../{LICENSE,LICENSE-BINARY} ./
+popd
+zip -r brdf-win32.zip brdf-win32

--- a/src/brdf/BRDFMeasuredAniso.cpp
+++ b/src/brdf/BRDFMeasuredAniso.cpp
@@ -74,6 +74,7 @@ Index
 15	  reserved
 */
 
+#include <cstdlib>
 #include <string>
 #include <fstream>
 #include <string.h>

--- a/src/brdf/BRDFMeasuredMERL.cpp
+++ b/src/brdf/BRDFMeasuredMERL.cpp
@@ -43,6 +43,7 @@ implied warranties of merchantability, fitness for a particular purpose and non-
 infringement.
 */
 
+#include <cstdlib>
 #include <string>
 #include <fstream>
 #include <string.h>

--- a/src/brdf/DGLFrameBuffer.cpp
+++ b/src/brdf/DGLFrameBuffer.cpp
@@ -156,7 +156,7 @@ void DGLFrameBuffer::bind()
     
     // First we bind the FBO so we can render to it
     glBindFramebuffer(GL_FRAMEBUFFER, _fboID);
-    
+  
     // adjust the viewport for this FBO
     glPushAttrib( GL_VIEWPORT_BIT );
     glViewport( 0, 0, _width, _height );

--- a/src/brdf/IBLWidget.cpp
+++ b/src/brdf/IBLWidget.cpp
@@ -208,8 +208,8 @@ void IBLWidget::randomizeSampleGroupOrder()
     // now swap random elements a bunch of times to shuffle the pass order
     for( int i = 0; i < stepSize*100; i++ )
     {
-        int a = random() % stepSize;
-        int b = random() % stepSize;
+        int a = rand() % stepSize;
+        int b = rand() % stepSize;
         int temp = sampleGroupOrder[a];
         sampleGroupOrder[a] = sampleGroupOrder[b];
         sampleGroupOrder[b] = temp;
@@ -744,7 +744,7 @@ void IBLWidget::loadIBL( const char* filename )
     printf( "opening %s\n", filename );
 
     // try and load it
-    std::string error;
+    Ptex::String error;
     PtexTexture* tx = PtexTexture::open(filename, error);
     if (!tx) return;
 

--- a/src/brdf/LitSphereWidget.cpp
+++ b/src/brdf/LitSphereWidget.cpp
@@ -45,7 +45,6 @@ infringement.
 
 #include <GL/glew.h>
 #include <QtGui>
-#include <QtOpenGL>
 #include <QString>
 #include <math.h>
 #include "DGLShader.h"

--- a/src/brdf/Plot3DWidget.cpp
+++ b/src/brdf/Plot3DWidget.cpp
@@ -45,7 +45,6 @@ infringement.
 
 #include <GL/glew.h>
 #include <QtGui>
-#include <QtOpenGL>
 #include <QString>
 #include <math.h>
 #include "DGLShader.h"

--- a/src/brdf/brdf.pro
+++ b/src/brdf/brdf.pro
@@ -55,7 +55,7 @@ SOURCES = \
 
 
 QT   += opengl
-LIBS += -lGLEW
+DEFINES += GLEW_STATIC
 
 macx {
 	INCLUDEPATH += /usr/X11/include
@@ -80,3 +80,20 @@ pkgconfig.path = $$DEST/$$LIBDIR/pkgconfig
 pkgconfig.files = brdf.pc
 
 INSTALLS = target brdfs data images probes shaderTemplates pkgconfig
+
+
+!linux-mingw32-custom{
+    LIBS += -lGLEW
+}
+
+# Windows cross compile at disney
+linux-mingw32-custom{
+    WINDOWS_BUILD=/jobs2/soft/users/aselle/windows-build
+    INCLUDEPATH += $$WINDOWS_BUILD/glew-1.9.0/include/
+    INCLUDEPATH += $$WINDOWS_BUILD/glut-3.7.6-bin/
+    LIBS += -L$$WINDOWS_BUILD/glut-3.7.6-bin/
+    LIBS += -L$$WINDOWS_BUILD/glew-1.9.0/lib/
+    LIBS += -static-libgcc
+    LIBS += -lglew32s
+
+}

--- a/src/brdf/main.cpp
+++ b/src/brdf/main.cpp
@@ -51,7 +51,14 @@ infringement.
 #include "ParameterWindow.h"
 #include "Paths.h"
 
+#include <iostream>
+#include <sstream>
+#ifdef WIN32
+#include <windows.h>
+#include <fcntl.h>
+#endif
 
+#define BRDF_VERSION "1.0.0"
 
 bool checkTeapot()
 {
@@ -67,6 +74,24 @@ bool checkTeapot()
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+
+#ifdef WIN32
+    // Make sure there is a console to get our stdout,stderr information
+    AllocConsole();
+    HANDLE stdOutHandle=GetStdHandle(STD_OUTPUT_HANDLE);
+    int hConHandle=_open_osfhandle((intptr_t)stdOutHandle,_O_TEXT);
+    FILE* fp=_fdopen((int)hConHandle,"w");
+    *stdout=*fp;
+    setvbuf(stdout,NULL,_IONBF,0);
+    HANDLE stdErrHandle=GetStdHandle(STD_ERROR_HANDLE);
+    int hConHandleErr=_open_osfhandle((intptr_t) stdOutHandle,_O_TEXT);
+    FILE* fperr=_fdopen( (int)hConHandleErr,"w");
+    *stderr=*fperr;
+    setvbuf(stderr,NULL,_IONBF,0);
+    std::ios::sync_with_stdio();
+    std::cerr<<"BRDF Version "<<BRDF_VERSION<<std::endl;
+//    std::cerr<<"stdout: BRDF Version "<<BRDF_VERSION<<std::endl;
+#endif
 
     // make sure we can open the data files
     if( !checkTeapot() ) {

--- a/src/brdf/ptex/PtexCache.cpp
+++ b/src/brdf/ptex/PtexCache.cpp
@@ -225,10 +225,18 @@ public:
 	_searchdirs.clear();
 	char* buff = strdup(path);
 	char* pos = 0;
+#ifdef WIN32
+	char* token = strtok(buff, ":");
+#else
 	char* token = strtok_r(buff, ":", &pos);
+#endif
 	while (token) {
 	    if (token[0]) _searchdirs.push_back(token);
+#ifdef WIN32
+	    token = strtok(0, ":");
+#else
 	    token = strtok_r(0, ":", &pos);
+#endif
 	}
 	free(buff);
     }

--- a/src/brdf/ptex/PtexHalf.h
+++ b/src/brdf/ptex/PtexHalf.h
@@ -41,6 +41,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
   @brief Half-precision floating-point type.
 */
 
+// this is extracted from library, so it should be static always
+#define PTEX_STATIC
+
 #ifndef PTEXAPI
 #  if defined(_WIN32) || defined(_WINDOWS) || defined(_MSC_VER)
 #    ifndef PTEX_STATIC

--- a/src/brdf/ptex/PtexPlatform.h
+++ b/src/brdf/ptex/PtexPlatform.h
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #define NOMINMAX 1
 
 // windows - defined for both Win32 and Win64
-#include <Windows.h>
+#include <windows.h>
 #include <malloc.h>
 #include <io.h>
 #include <tchar.h> 

--- a/src/brdf/ptex/PtexReader.cpp
+++ b/src/brdf/ptex/PtexReader.cpp
@@ -80,7 +80,7 @@ bool PtexReader::open(const char* path, Ptex::String& error)
 	return 0;
     }
     if (_header.version != 1) {
-	char ver[21]; snprintf(ver, 20, "%d", _header.version);
+	char ver[21]; sprintf(ver, "%d", _header.version);
 	std::string errstr = "Unsupported ptex file version (";
 	errstr += ver; errstr += "): "; errstr += path;
 	error = errstr.c_str();

--- a/src/brdf/ptex/PtexReader.h
+++ b/src/brdf/ptex/PtexReader.h
@@ -555,7 +555,14 @@ protected:
             else buffer = 0;
             return (Handle) fp;
         }
-        virtual void seek(Handle handle, int64_t pos) { fseeko((FILE*)handle, pos, SEEK_SET); }
+        virtual void seek(Handle handle, int64_t pos) { 
+#ifdef WIN32
+            fseek((FILE*)handle,pos,SEEK_SET);
+#else
+            fseeko((FILE*)handle, pos, SEEK_SET); 
+#endif
+
+        }
         virtual size_t read(void* buffer, size_t size, Handle handle) {
             return fread(buffer, size, 1, (FILE*)handle) == 1 ? size : 0;
         }

--- a/src/brdf/ptex/Ptexture.h
+++ b/src/brdf/ptex/Ptexture.h
@@ -41,6 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
   @brief Public API classes for reading, writing, caching, and filtering Ptex files.
 */
 
+// ptex is static because we aren't building a library
+#define PTEX_STATIC
 #if defined(_WIN32) || defined(_WINDOWS) || defined(_MSC_VER)
 # ifndef PTEXAPI
 #  ifndef PTEX_STATIC


### PR DESCRIPTION
Make all ptex includes not create declimport's to avoid link problems
Include cstdlib when malloc functions being used
Create script to create binary distribution on windows
Allocate console so we can see stdout and stderr in windows case
