### PR TITLE
Fix typo in Paul HDR light probe copyright year

### DIFF
--- a/README
+++ b/README
@@ -128,7 +128,7 @@ refer to them knowing that they'll exist and have the proper values at runtime.
 
 LIGHT PROBE ATTRIBUTION
 ------------------------------------
-HDR Light Probe Images Copyright 1988 courtesy of Paul Debevec,
+HDR Light Probe Images Copyright 1998 courtesy of Paul Debevec,
 www.debevec.org, used with permission.
 
 Please see:


### PR DESCRIPTION
Note: The copyright date is also incorrect on the website (last paragraph):
http://www.disneyanimation.com/technology/brdf.html